### PR TITLE
Workflow and Form Element models

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It doesn't.
 ### Ingest workflow creator
 
 The gist is that it'll treat an HTML form like a tree and allow the nodes of the tree to be
-added and manipulated based on rules of how HTML forms actualy work.
+added and manipulated based on rules of how HTML forms work.
 
 For instance, `fieldset` can be added to a `form` element, but a `form` cannot be added to
 a `fieldset`.

--- a/app/models/element.rb
+++ b/app/models/element.rb
@@ -1,0 +1,53 @@
+# == Schema Information
+#
+# Table name: elements
+#
+#  id              :integer          not null, primary key
+#  workflow_id     :integer
+#  element_type_id :integer
+#  label           :string
+#  help            :string
+#  error           :string
+#  parent_id       :integer
+#  required        :boolean          default(FALSE)
+#  position        :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
+class Element < ActiveRecord::Base
+  belongs_to :workflow
+  belongs_to :element_type
+  validates :workflow_id, presence: true
+  validates :element_type_id, presence: true
+  validates_associated :element_type
+  validate :legal_parent
+  belongs_to :parent, class_name: 'Element'
+  has_many :children, -> { order(:position) },
+           class_name: 'Element',
+           foreign_key: 'parent_id'
+  acts_as_list scope: :parent
+
+  def accepts_type?(element_type)
+    accepted_element_types.include?(element_type)
+  end
+
+  def accepted_element_type_ids
+    element_type.element_type_accepts.map(&:accepts_element_type_id)
+  end
+
+  def accepted_element_types
+    ElementType.where(id: accepted_element_type_ids).order(:name)
+  end
+
+  def legal_parent
+    return unless parent.present?
+    return if parent.accepts_type?(element_type)
+    errors.add(:element_type_id, "You can't add this Element here")
+  end
+
+  def traverse(&block)
+    yield self
+    children.map { |child| child.traverse(&block) }
+  end
+end

--- a/app/models/element_type.rb
+++ b/app/models/element_type.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: element_types
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class ElementType < ActiveRecord::Base
+  has_many :elements
+  has_many :element_type_accepts
+  validates :name, presence: true
+end

--- a/app/models/element_type_accept.rb
+++ b/app/models/element_type_accept.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: element_type_accepts
+#
+#  id                      :integer          not null, primary key
+#  element_type_id         :integer
+#  accepts_element_type_id :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+
+class ElementTypeAccept < ActiveRecord::Base
+  belongs_to :element_types
+  validates :element_type_id, presence: true
+  validates :accepts_element_type_id, presence: true
+end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: workflows
+#
+#  id         :integer          not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class Workflow < ActiveRecord::Base
+  has_many :elements, -> { order(position: :asc) }, dependent: :destroy
+  validates :name, presence: true
+end

--- a/db/migrate/20151007185531_create_workflows.rb
+++ b/db/migrate/20151007185531_create_workflows.rb
@@ -1,0 +1,8 @@
+class CreateWorkflows < ActiveRecord::Migration
+  def change
+    create_table :workflows do |t|
+      t.string :name, null: false
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20151007185535_create_elements.rb
+++ b/db/migrate/20151007185535_create_elements.rb
@@ -1,0 +1,15 @@
+class CreateElements < ActiveRecord::Migration
+  def change
+    create_table :elements do |t|
+      t.belongs_to :workflow, index: true
+      t.belongs_to :element_type, index: true
+      t.string :label
+      t.string :help
+      t.string :error
+      t.integer :parent_id
+      t.boolean :required, default: false
+      t.integer :position
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20151007185548_create_element_types.rb
+++ b/db/migrate/20151007185548_create_element_types.rb
@@ -1,0 +1,8 @@
+class CreateElementTypes < ActiveRecord::Migration
+  def change
+    create_table :element_types do |t|
+      t.string :name
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20151007191505_create_element_type_accepts.rb
+++ b/db/migrate/20151007191505_create_element_type_accepts.rb
@@ -1,0 +1,9 @@
+class CreateElementTypeAccepts < ActiveRecord::Migration
+  def change
+    create_table :element_type_accepts do |t|
+      t.belongs_to :element_type
+      t.integer :accepts_element_type_id
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,48 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150929173815) do
-
-  create_table "users", force: :cascade do |t|
-    t.string   "email",      null: false
-    t.string   "uid",        null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+ActiveRecord::Schema.define(version: 20_151_007_191_505) do
+  create_table 'element_type_accepts', force: :cascade do |t|
+    t.integer 'element_type_id'
+    t.integer 'accepts_element_type_id'
+    t.datetime 'created_at',              null: false
+    t.datetime 'updated_at',              null: false
   end
 
-  add_index "users", ["uid"], name: "index_users_on_uid", unique: true
+  create_table 'element_types', force: :cascade do |t|
+    t.string 'name'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+  end
 
+  create_table 'elements', force: :cascade do |t|
+    t.integer 'workflow_id'
+    t.integer 'element_type_id'
+    t.string 'label'
+    t.string 'help'
+    t.string 'error'
+    t.integer 'parent_id'
+    t.boolean 'required', default: false
+    t.integer 'position'
+    t.datetime 'created_at',                      null: false
+    t.datetime 'updated_at',                      null: false
+  end
+
+  add_index 'elements', ['element_type_id'], name: 'index_elements_on_element_type_id'
+  add_index 'elements', ['workflow_id'], name: 'index_elements_on_workflow_id'
+
+  create_table 'users', force: :cascade do |t|
+    t.string 'email',      null: false
+    t.string 'uid',        null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+  end
+
+  add_index 'users', ['uid'], name: 'index_users_on_uid', unique: true
+
+  create_table 'workflows', force: :cascade do |t|
+    t.string 'name', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+  end
 end

--- a/test/fixtures/element_type_accepts.yml
+++ b/test/fixtures/element_type_accepts.yml
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: element_type_accepts
+#
+#  id                      :integer          not null, primary key
+#  element_type_id         :integer
+#  accepts_element_type_id :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+form_input_text:
+  element_type_id: 1
+  accepts_element_type_id: 2
+
+form_fieldset:
+  element_type_id: 1
+  accepts_element_type_id: 7
+
+fieldset_input_text:
+  element_type_id: 7
+  accepts_element_type_id: 2

--- a/test/fixtures/element_types.yml
+++ b/test/fixtures/element_types.yml
@@ -1,0 +1,51 @@
+# == Schema Information
+#
+# Table name: element_types
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+form:
+  id: 1
+  name: 'form'
+
+input_text:
+  id: 2
+  name: 'input_text'
+
+input_radio:
+  id: 3
+  name: 'input_radio'
+
+input_checkbox:
+  id: 4
+  name: 'input_checkbox'
+
+input_submit:
+  id: 5
+  name: 'input_submit'
+
+textarea:
+  id: 6
+  name: 'textarea'
+
+fieldset:
+  id: 7
+  name: 'fieldset'
+
+select:
+  id: 8
+  name: 'select'
+
+option:
+  id: 9
+  name: 'option'

--- a/test/fixtures/elements.yml
+++ b/test/fixtures/elements.yml
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: elements
+#
+#  id              :integer          not null, primary key
+#  workflow_id     :integer
+#  element_type_id :integer
+#  label           :string
+#  help            :string
+#  error           :string
+#  parent_id       :integer
+#  required        :boolean          default(FALSE)
+#  position        :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one:
+  workflow_id: 1
+  element_type_id: 1

--- a/test/fixtures/workflows.yml
+++ b/test/fixtures/workflows.yml
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: workflows
+#
+#  id         :integer          not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+workflow_one:
+  id: 1
+  name: 'popcorn flow'
+
+two:
+  id: 2
+  name: 'doe'

--- a/test/models/element_test.rb
+++ b/test/models/element_test.rb
@@ -1,0 +1,117 @@
+# == Schema Information
+#
+# Table name: elements
+#
+#  id              :integer          not null, primary key
+#  workflow_id     :integer
+#  element_type_id :integer
+#  label           :string
+#  help            :string
+#  error           :string
+#  parent_id       :integer
+#  required        :boolean          default(FALSE)
+#  position        :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
+require 'test_helper'
+
+class ElementTest < ActiveSupport::TestCase
+  def setup
+    @workflow = workflows(:workflow_one)
+    @element = elements(:one)
+  end
+
+  test 'should be valid' do
+    assert @element.valid?
+  end
+
+  test 'workflow_id should be present' do
+    @element.workflow_id = ''
+    assert @element.invalid?
+  end
+
+  test 'element_type_id should be present' do
+    @element.element_type_id = ''
+    assert @element.invalid?
+  end
+
+  test 'accepted_element_type_ids' do
+    input_text_id = element_types(:input_text).id
+    fieldset_id = element_types(:fieldset).id
+    form_id = element_types(:form).id
+    textarea_id = element_types(:textarea).id
+    assert @element.accepted_element_type_ids.include?(input_text_id)
+    assert @element.accepted_element_type_ids.include?(fieldset_id)
+    assert @element.accepted_element_type_ids.exclude?(form_id)
+    assert @element.accepted_element_type_ids.exclude?(textarea_id)
+  end
+
+  test 'accepted_element_types' do
+    assert @element.accepted_element_types.include?(element_types(:input_text))
+    assert @element.accepted_element_types.include?(element_types(:fieldset))
+    assert @element.accepted_element_types.exclude?(element_types(:form))
+    assert @element.accepted_element_types.exclude?(element_types(:textarea))
+  end
+
+  test 'accepts_type' do
+    assert @element.accepts_type?(element_types(:input_text))
+    assert @element.accepts_type?(element_types(:fieldset))
+    assert_not @element.accepts_type?(element_types(:form))
+    assert_not @element.accepts_type?(element_types(:textarea))
+  end
+
+  test 'valid with legal_parent' do
+    parent = elements(:one)
+    e = Element.new(workflow_id: 1, element_type_id: 2, parent_id: parent.id)
+    assert e.valid?
+  end
+
+  test 'invalid with illegal_parent' do
+    parent = elements(:one)
+    e = Element.new(workflow_id: 1, element_type_id: 3, parent_id: parent.id)
+    assert e.invalid?
+  end
+
+  test 'can move up in order' do
+    workflow = workflows(:workflow_one)
+    parent = elements(:one)
+    e1 = Element.create(workflow_id: workflow.id, label: 'e1',
+                        element_type_id: 2, parent_id: parent.id)
+    e2 = Element.create(workflow_id: workflow.id, label: 'e2',
+                        element_type_id: 2, parent_id: parent.id)
+    assert_equal(1, e1.position)
+    assert_equal(2, e2.position)
+    assert_equal(e1, parent.children.first)
+    assert_equal(e2, parent.children.last)
+    parent.children.first.move_lower
+    assert_equal(2, e1.reload.position)
+    assert_equal(1, e2.reload.position)
+    assert_equal(e2, parent.children.first)
+    assert_equal(e1, parent.children.last)
+  end
+
+  test 'traverse from root' do
+    workflow = workflows(:workflow_one)
+    top_form = elements(:one)
+    top_form.label = 'form'
+    top_form.save!
+    Element.create(workflow_id: workflow.id, label: 'input_text',
+                   element_type_id: 2, parent_id: top_form.id)
+    fs1 = Element.create(workflow_id: workflow.id, label: 'fieldset_one',
+                         element_type_id: 7, parent_id: top_form.id)
+    Element.create(workflow_id: workflow.id, label: 'fieldset_two',
+                   element_type_id: 7, parent_id: top_form.id)
+    Element.create(workflow_id: workflow.id, label: 'input_text2',
+                   element_type_id: 2, parent_id: fs1.id)
+    a = []
+    top_form.traverse { |e, f| a << "#{e.label}#{f}" }
+    assert_equal(5, a.size)
+    assert_equal('form', a[0])
+    assert_equal('input_text', a[1])
+    assert_equal('fieldset_one', a[2])
+    assert_equal('input_text2', a[3])
+    assert_equal('fieldset_two', a[4])
+  end
+end

--- a/test/models/element_type_accept_test.rb
+++ b/test/models/element_type_accept_test.rb
@@ -1,0 +1,42 @@
+# == Schema Information
+#
+# Table name: element_type_accepts
+#
+#  id                      :integer          not null, primary key
+#  element_type_id         :integer
+#  accepts_element_type_id :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+
+require 'test_helper'
+
+class ElementTypeAcceptTest < ActiveSupport::TestCase
+  def setup
+    @element_type_accepts = element_type_accepts(:form_input_text)
+  end
+
+  test 'is valid' do
+    assert @element_type_accepts.valid?
+  end
+
+  test 'requires element_type_id' do
+    @element_type_accepts.element_type_id = ''
+    assert @element_type_accepts.invalid?
+  end
+
+  test 'requires accepts_element_type_id' do
+    @element_type_accepts.accepts_element_type_id = ''
+    assert @element_type_accepts.invalid?
+  end
+
+  test 'element type can be nested if allowed' do
+    @element_type_one = element_types(:form)
+    @element_type_two = element_types(:input_text)
+  end
+
+  test 'element type cannot be nested if not allowed' do
+    @element_type_one = element_types(:form)
+    @element_type_two = element_types(:input_text)
+  end
+end

--- a/test/models/element_type_test.rb
+++ b/test/models/element_type_test.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: element_types
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+require 'test_helper'
+
+class ElementTypeTest < ActiveSupport::TestCase
+  def setup
+    @element_type = element_types(:form)
+  end
+
+  test 'element_type_count' do
+    assert_equal(9, ElementType.count)
+  end
+
+  test 'is valid' do
+    assert @element_type.valid?
+  end
+
+  test 'name should be present' do
+    @element_type.name = ''
+    assert @element_type.invalid?
+  end
+end

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: workflows
+#
+#  id         :integer          not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+require 'test_helper'
+
+class WorkflowTest < ActiveSupport::TestCase
+  def setup
+    @workflow = workflows(:workflow_one)
+  end
+
+  test 'should be valid' do
+    assert @workflow.valid?
+  end
+
+  test 'name should be present' do
+    @workflow.name = ''
+    assert_not @workflow.valid?
+  end
+end


### PR DESCRIPTION
This work enables the construction and manipulation of valid workflow processing form tree structures.

Put another way, you can create a workflow and include form elements that can be configured to only nest into a tree structure that will produce a valid HTML form.

The actual form production (Views) work and admin interface for creating such is not completed yet and it's possible that portions of this will need refactoring once that work begins. The intention is to have the form elements all in separate view partials that can be included as necessary to construct the form dynamically at page request time.
